### PR TITLE
[#36] Feat: "회원 권한 수정 구현"

### DIFF
--- a/com.nuttty.eureka.auth/src/main/java/com/nuttty/eureka/auth/application/service/UserService.java
+++ b/com.nuttty.eureka.auth/src/main/java/com/nuttty/eureka/auth/application/service/UserService.java
@@ -4,6 +4,7 @@ import com.nuttty.eureka.auth.application.dto.UserInfoDto;
 import com.nuttty.eureka.auth.domain.model.User;
 import com.nuttty.eureka.auth.domain.model.UserRoleEnum;
 import com.nuttty.eureka.auth.domain.repository.UserRepository;
+import com.nuttty.eureka.auth.presentation.request.UserRoleUpdateRequestDto;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
@@ -16,18 +17,35 @@ public class UserService {
 
     // 회원 상세 조회
     @Transactional(readOnly = true)
-    public UserInfoDto getUserInfo(Long loggedUserId, Long targetUserId) {
+    public UserInfoDto getUserInfo(String role, Long loggedUserId, Long targetUserId) {
         // 조회 유저 가입 여부 검사
         User targetUser = userRepository.findById(targetUserId)
                 .orElseThrow(() -> new IllegalArgumentException("등록되지 않은 유저입니다."));
-        // 로그인 유저 가입 여부 검사
-        User loggedUser = userRepository.findById(loggedUserId)
-                .orElseThrow(() -> new IllegalArgumentException("등록되지 않은 유저입니다."));
+
         // 로그인 유저의 정보와 조회 할 유저의 정보 일치 검사 & 로그인 유저 권한 체크
-        if(!loggedUserId.equals(targetUserId) && !loggedUser.getRole().equals(UserRoleEnum.MASTER)) {
+        if(!loggedUserId.equals(targetUserId) && !UserRoleEnum.valueOf(role).equals(UserRoleEnum.MASTER)) {
             throw new IllegalArgumentException("해당 유저의 정보를 조회 할 권한이 없습니다.");
         }
 
         return UserInfoDto.of(targetUser);
+    }
+
+
+    // 회원 권한 수정 - 토큰 재발급
+    @Transactional
+    public UserInfoDto updateUserRole(String role, Long targetUserId, UserRoleUpdateRequestDto updateRequestDto) {
+        // 조회 유저 가입 여부 검사
+        User user = userRepository.findById(targetUserId)
+                .orElseThrow(() -> new IllegalArgumentException("등록되지 않은 유저입니다."));
+
+        // 로그인 유저 권한 체크
+        if(!UserRoleEnum.valueOf(role).equals(UserRoleEnum.MASTER)) {
+            throw new IllegalArgumentException("해당 유저의 정보를 수정 할 권한이 없습니다.");
+        }
+
+        // 회원 권한 수정
+        user.updateUserRole(UserRoleEnum.valueOf(updateRequestDto.getRole()));
+
+        return UserInfoDto.of(user);
     }
 }

--- a/com.nuttty.eureka.auth/src/main/java/com/nuttty/eureka/auth/domain/model/User.java
+++ b/com.nuttty.eureka.auth/src/main/java/com/nuttty/eureka/auth/domain/model/User.java
@@ -41,4 +41,8 @@ public class User extends AuditEntity {
                 .role(role)
                 .build();
     }
+
+
+    // 회원 role 수정
+    public void updateUserRole(UserRoleEnum role) {this.role = role;}
 }

--- a/com.nuttty.eureka.auth/src/main/java/com/nuttty/eureka/auth/presentation/controller/UserController.java
+++ b/com.nuttty.eureka.auth/src/main/java/com/nuttty/eureka/auth/presentation/controller/UserController.java
@@ -2,6 +2,7 @@ package com.nuttty.eureka.auth.presentation.controller;
 
 import com.nuttty.eureka.auth.application.dto.UserInfoDto;
 import com.nuttty.eureka.auth.application.service.UserService;
+import com.nuttty.eureka.auth.presentation.request.UserRoleUpdateRequestDto;
 import com.nuttty.eureka.auth.util.ResultResponse;
 import com.nuttty.eureka.auth.util.SuccessCode;
 import lombok.RequiredArgsConstructor;
@@ -16,13 +17,27 @@ public class UserController {
 
     // 회원 상세 조회
     @GetMapping("/{user_id}")
-    public ResultResponse<UserInfoDto> getUserInfo(@RequestHeader("X-User-Id") Long loggedUserId,
+    public ResultResponse<UserInfoDto> getUserInfo(@RequestHeader("X-User-Role") String role,
+                                                   @RequestHeader("X-User-Id") Long loggedUserId,
                                                    @PathVariable("user_id") Long targetUserId) {
 
         return ResultResponse.<UserInfoDto>builder()
-                .data(userService.getUserInfo(loggedUserId, targetUserId))
+                .data(userService.getUserInfo(role, loggedUserId, targetUserId))
                 .resultCode(SuccessCode.SELECT_SUCCESS.getStatus())
                 .resultMessage(SuccessCode.SELECT_SUCCESS.getMessage())
+                .build();
+    }
+
+    // 회원 권한 수정
+    @PatchMapping("/{user_id}")
+    public ResultResponse<UserInfoDto> updateUserRole(@RequestHeader("X-User-Role") String role,
+                                                      @PathVariable("user_id") Long targetUserId,
+                                                      @RequestBody UserRoleUpdateRequestDto updateRequestDto) {
+
+        return ResultResponse.<UserInfoDto>builder()
+                .data(userService.updateUserRole(role, targetUserId, updateRequestDto))
+                .resultCode(SuccessCode.UPDATE_SUCCESS.getStatus())
+                .resultMessage(SuccessCode.UPDATE_SUCCESS.getMessage())
                 .build();
     }
 }

--- a/com.nuttty.eureka.auth/src/main/java/com/nuttty/eureka/auth/presentation/request/UserRoleUpdateRequestDto.java
+++ b/com.nuttty.eureka.auth/src/main/java/com/nuttty/eureka/auth/presentation/request/UserRoleUpdateRequestDto.java
@@ -1,0 +1,8 @@
+package com.nuttty.eureka.auth.presentation.request;
+
+import lombok.Getter;
+
+@Getter
+public class UserRoleUpdateRequestDto {
+    private String role;
+}

--- a/com.nuttty.eureka.auth/src/main/java/com/nuttty/eureka/auth/util/AuditorAwareImpl.java
+++ b/com.nuttty.eureka.auth/src/main/java/com/nuttty/eureka/auth/util/AuditorAwareImpl.java
@@ -14,7 +14,7 @@ public class AuditorAwareImpl implements AuditorAware<String> {
 
     @Override
     public Optional<String> getCurrentAuditor() {
-        String byWho = httpServletRequest.getHeader("X-User-Id");
+        String byWho = httpServletRequest.getHeader("X-User-Email");
         if (!StringUtils.hasText(byWho)) {
             byWho = "system";
         }

--- a/com.nuttty.eureka.auth/src/main/resources/application.yml
+++ b/com.nuttty.eureka.auth/src/main/resources/application.yml
@@ -34,6 +34,6 @@ eureka:
       defaultZone: http://localhost:19090/eureka/
 
 jwt:
-  access-expiration: 360000
+  access-expiration: 3600000
   secret-key: "7Iqk7YyM66W07YOA7L2U65Sp7YG065-9U3ByaW5n6rCV7J2Y7Yqc7YSw7LWc7JuQ67mI7J6F64uI64ukLg=="
   admin-token: AIzaSyBZFANrsha1UH5CaSDUxtfdXaTQ5yOtPhE


### PR DESCRIPTION
Resolves: #36

## 이슈 번호

Issue📌: #36 
## PR 체크리스트
- [x] 커밋 컨벤션에 맞게 작성했는가?
- [x] PR 전에 dev를 pull 받았는가?
- [x] PR 전에 develop 브랜치로 merge 하였는가?


## PR 작업 분류

<!-- Please check the one that applies to this PR using "x". -->

- [x] 신규 기능
- [ ] 버그 수정
- [ ] 리팩토링
- [ ] 기타

## 작업 상세 내용
- 회원의 권한 수정 기능 
- MASTER 권한의 사용자만 사용 가능
- MASTER만 접근이 가능한 조건으로 권한 외에 다른 정보를 수정할 필요성을 느끼지 X

+ 추가로 회원 정보 상세 조회시 로그인한 유저의 role을 얻기 위한 작업으로 loggedUser를 조회하는 쿼리 제거 x
👉 RequestHeader로 받아온 유저의 권한을 사용

### 개선 필요
- [ ] PreAuthorize, Secured 어노테이션을 사용한 간편한 코드 작성 - develop

## 다음 할 일


## 질문 사항


**💬질문 내용**


**🔴 이건 반드시 확인해 주세요!**
