### PR TITLE
[#60] Refactor: "Auth - Verify 메소드 캐싱"

### DIFF
--- a/com.nuttty.eureka.auth/src/main/java/com/nuttty/eureka/auth/application/service/AuthService.java
+++ b/com.nuttty.eureka.auth/src/main/java/com/nuttty/eureka/auth/application/service/AuthService.java
@@ -14,6 +14,7 @@ import io.jsonwebtoken.security.Keys;
 import jakarta.persistence.EntityNotFoundException;
 import jakarta.transaction.Transactional;
 import org.springframework.beans.factory.annotation.Value;
+import org.springframework.cache.annotation.Cacheable;
 import org.springframework.dao.DataIntegrityViolationException;
 import org.springframework.data.redis.core.RedisTemplate;
 import org.springframework.security.authentication.BadCredentialsException;
@@ -112,8 +113,12 @@ public class AuthService {
                 ).orElseThrow(() -> new EntityNotFoundException("Reject createAccessToken: 존재하지 않는 유저입니다."));
     }
 
+
     // userId 존재여부 검증 API
-    public Boolean verifyUser(Long userId) {
-        return userRepository.findById(userId).isPresent();
+    @Cacheable(cacheNames = "userInfoCache", key = "#userId")
+    public UserInfoDto verifyUser(Long userId) {
+        return userRepository.findById(userId)
+                .map(UserInfoDto::of) // User가 존재하면 UserInfoDto로 변환
+                .orElse(null); // 없으면 null 반환
     }
 }

--- a/com.nuttty.eureka.auth/src/main/java/com/nuttty/eureka/auth/application/service/UserService.java
+++ b/com.nuttty.eureka.auth/src/main/java/com/nuttty/eureka/auth/application/service/UserService.java
@@ -14,7 +14,6 @@ import org.springframework.cache.annotation.CachePut;
 import org.springframework.cache.annotation.Cacheable;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
-import org.springframework.security.access.AccessDeniedException;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 

--- a/com.nuttty.eureka.auth/src/main/java/com/nuttty/eureka/auth/infrastructure/configuration/CacheConfig.java
+++ b/com.nuttty.eureka.auth/src/main/java/com/nuttty/eureka/auth/infrastructure/configuration/CacheConfig.java
@@ -14,29 +14,21 @@ import java.time.Duration;
 import static org.springframework.data.redis.serializer.RedisSerializationContext.SerializationPair;
 
 @Configuration
-@EnableCaching // 📌Cache 관련 어노테이션을 사용할 수 있게 해줌
+@EnableCaching // Cache 관련 어노테이션을 사용
 public class CacheConfig {
 
     @Bean
     // CacheManager로 진행해도 정상 동작
-    public RedisCacheManager cacheManager(
-            RedisConnectionFactory redisConnectionFactory
-    ) {
-        // 설정 구성을 먼저 진행한다.
+    public RedisCacheManager cacheManager(RedisConnectionFactory redisConnectionFactory) {
         // Redis를 이용해서 Spring Cache를 사용할 때
         // Redis 관련 설정을 모아두는 클래스
         RedisCacheConfiguration configuration = RedisCacheConfiguration
                 .defaultCacheConfig()
-                // null을 캐싱 할것인지
-                .disableCachingNullValues()
-                // 기본 캐시 유지 시간 (Time To Live)
-                .entryTtl(Duration.ofSeconds(50000))
-                // 캐시를 구분하는 접두사 설정
-                .computePrefixWith(CacheKeyPrefix.simple())
-                // 캐시에 저장할 값을 어떻게 직렬화 / 역직렬화 할것인지
-                .serializeValuesWith(
-                        SerializationPair.fromSerializer(RedisSerializer.java())
-                );
+                .disableCachingNullValues() // null을 캐싱 할것인지
+                .entryTtl(Duration.ofSeconds(120)) // 기본 캐시 유지 시간 (Time To Live)
+                .computePrefixWith(CacheKeyPrefix.simple()) // 캐시를 구분하는 접두사 설정
+                .serializeValuesWith( // 캐시에 저장할 값을 어떻게 직렬화 / 역직렬화 할것인지
+                        SerializationPair.fromSerializer(RedisSerializer.java()));
 
         return RedisCacheManager
                 .builder(redisConnectionFactory)

--- a/com.nuttty.eureka.auth/src/main/java/com/nuttty/eureka/auth/presentation/controller/AuthController.java
+++ b/com.nuttty.eureka.auth/src/main/java/com/nuttty/eureka/auth/presentation/controller/AuthController.java
@@ -44,7 +44,9 @@ public class AuthController {
     // userId 존재여부 검증 API
     @GetMapping("/verify")
     public ResponseEntity<Boolean> verifyUser(final @RequestParam(value = "user_id") Long userId) {
-        Boolean response = authService.verifyUser(userId);
+        UserInfoDto userInfo = authService.verifyUser(userId);
+        Boolean response = (userInfo != null); // 유저가 존재하면 true, 존재하지 않으면 false
+
         return ResponseEntity.ok(response);
     }
 }


### PR DESCRIPTION
Resolves: #60

## 이슈 번호

Issue📌: #60 

## PR 체크리스트
- [x] 커밋 컨벤션에 맞게 작성했는가?
- [x] PR 전에 dev를 pull 받았는가?
- [x] PR 전에 develop 브랜치로 merge 하였는가?


## PR 작업 분류

<!-- Please check the one that applies to this PR using "x". -->

- [ ] 신규 기능
- [ ] 버그 수정
- [x] 리팩토링
- [ ] 기타

## 작업 상세 내용
### Gateway에서 사용하는 사용자 등록여부 체크 메소드 캐싱 기능 추가

- 각 메소드에 캐싱 기능을 추가했는데 캐싱은 적용 됨
- 하지만 쿼리가 계속 날아감
- 헤더 차이 문제인가? 싶었음
- 로깅 결과 쿼리가 날아오는 출처가 캐싱을 해놓은 메서드가 아니였음.
- 원인은 Gateway에서 사용자 검증을 위해 사용하는 AuthService의 verify메소드 쿼리였다.

## 다음 할 일


## 질문 사항


**💬질문 내용**


**🔴 이건 반드시 확인해 주세요!**
