### PR TITLE
[#72] Feat: "배송 담당자 개별 조회 기능 구현 & 등록 기능 권한 별 검사 로직 추가"

### DIFF
--- a/com.nuttty.eureka.auth/src/main/java/com/nuttty/eureka/auth/application/service/DeliveryPersonService.java
+++ b/com.nuttty.eureka.auth/src/main/java/com/nuttty/eureka/auth/application/service/DeliveryPersonService.java
@@ -4,6 +4,8 @@ import com.nuttty.eureka.auth.application.client.HubClient;
 import com.nuttty.eureka.auth.application.dto.DeliveryPersonInfoDto;
 import com.nuttty.eureka.auth.domain.model.DeliveryPerson;
 import com.nuttty.eureka.auth.domain.model.DeliveryPersonTypeEnum;
+import com.nuttty.eureka.auth.domain.model.User;
+import com.nuttty.eureka.auth.domain.model.UserRoleEnum;
 import com.nuttty.eureka.auth.exception.custom.DeliveryPersonAlreadyExistsException;
 import com.nuttty.eureka.auth.infrastructure.repository.DeliveryPersonRepository;
 import com.nuttty.eureka.auth.infrastructure.repository.UserRepository;
@@ -12,6 +14,8 @@ import com.nuttty.eureka.auth.presentation.request.HubRequestDto;
 import jakarta.persistence.EntityNotFoundException;
 import lombok.RequiredArgsConstructor;
 import org.springframework.cache.annotation.CachePut;
+import org.springframework.cache.annotation.Cacheable;
+import org.springframework.security.access.AccessDeniedException;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -25,11 +29,29 @@ public class DeliveryPersonService {
 
 
     @Transactional
-    @CachePut(cacheNames = "deliveryPersonInfoCache", key = "#result.user_id")
-    public DeliveryPersonInfoDto createDeliveryPerson(DeliveryPersonCreateDto createDto) {
+    @CachePut(cacheNames = "deliveryPersonInfoCache", key = "#role + ':' + #userId + ':' + #result.user_id")
+    public DeliveryPersonInfoDto createDeliveryPerson(String role, Long userId, DeliveryPersonCreateDto createDto) {
         // 회원 가입 유무 검사
-        if (!userRepository.existsById(createDto.getUserId())) {
-            throw new EntityNotFoundException("등록되지 않는 유저입니다.");
+        User user = userRepository.findById(createDto.getUserId())
+                .orElseThrow(() -> new EntityNotFoundException("등록되지 않은 유저입니다."));
+
+        // 배송 담당자 권한 유저만 등록 가능
+        if (!user.getRole().equals(UserRoleEnum.HUB_DELIVERY_PERSON)) {
+            throw new AccessDeniedException("배송 담당자 권한인 유저가 아닙니다.");
+        }
+
+        // 허브 관리자 권한 경우
+        if (UserRoleEnum.valueOf(role).equals(UserRoleEnum.HUB_MANAGER)){
+            // 허브 존재 여부 검사
+            HubRequestDto hubInfo = hubClient.findOneHub(createDto.getHubId()).getBody();
+            if (hubInfo == null) {
+                throw new EntityNotFoundException("등록되지 않은 허브입니다.");
+            }
+
+            // 배송 담당자를 등록할 허브의 허브관리자와 로그인한 허브 매니저의 일치여부 검사
+            if(!hubInfo.getHubDto().getUser_id().equals(userId)){
+                throw new AccessDeniedException("허브 관리자님의 허브가 아닙니다.");
+            }
         }
 
         // 배송담당자 타입이 업체 배송 담당자인 경우, 소속 허브ID가 존재하는 허브인지 확인
@@ -39,6 +61,8 @@ public class DeliveryPersonService {
             if (hubInfo == null) {
                 throw new EntityNotFoundException("등록되지 않은 허브입니다.");
             }
+        } else { // 허브 이동 배송 담당자 경우 == 소속 허브 필요 x (등록 x)
+            createDto.setHubId(null);
         }
 
         // 배송 담당자로 등록된 회원인지 검사
@@ -53,6 +77,37 @@ public class DeliveryPersonService {
                         DeliveryPersonTypeEnum.valueOf(createDto.getDeliveryPersonType()),
                         createDto.getSlackId());
         deliveryPersonRepository.save(deliveryPerson);
+
+        return DeliveryPersonInfoDto.of(deliveryPerson);
+    }
+
+
+    // 배송 담당자 개별 조회
+    @Transactional(readOnly = true)
+    @Cacheable(cacheNames = "deliveryPersonInfoCache", key = "#role + ':' + #userId + ':' + #deliveryPersonId")
+    public DeliveryPersonInfoDto getDeliveryPersonInfo(String role, Long userId, Long deliveryPersonId) {
+        // 배송 담당자 등록 여부 검사
+        DeliveryPerson deliveryPerson = deliveryPersonRepository.findById(deliveryPersonId)
+                .orElseThrow(() -> new EntityNotFoundException("등록되지 않은 배송 담당자입니다."));
+
+        // 권한에 따른 구분
+        if (UserRoleEnum.valueOf(role).equals(UserRoleEnum.HUB_DELIVERY_PERSON)) { // 권한 == 배송 담당자
+            if (!userId.equals(deliveryPersonId)) { // 본인의 정보만 조회 가능 - deliveryPersonId == userId
+                throw new AccessDeniedException("본인의 정보가 아닙니다.");
+            }
+
+        } else if (UserRoleEnum.valueOf(role).equals(UserRoleEnum.HUB_MANAGER)) { // 권한 == 허브 관리자
+            // 배송 담당자의 허브의 허브 관리자 Id 가져오기
+            HubRequestDto hubInfo = hubClient.findOneHub(deliveryPerson.getHubId()).getBody();
+            if (hubInfo == null) {
+                throw new EntityNotFoundException("등록되지 않은 허브입니다.");
+            }
+
+            // 로그인한 유저와 허브 관리자 Id 비교
+            if (!userId.equals(hubInfo.getHubDto().getUser_id())) {
+                throw new AccessDeniedException("허브 관리자님 허브 소속의 배송담당자가 아닙니다.");
+            }
+        }
 
         return DeliveryPersonInfoDto.of(deliveryPerson);
     }

--- a/com.nuttty.eureka.auth/src/main/java/com/nuttty/eureka/auth/domain/model/DeliveryPerson.java
+++ b/com.nuttty.eureka.auth/src/main/java/com/nuttty/eureka/auth/domain/model/DeliveryPerson.java
@@ -13,7 +13,7 @@ import java.util.UUID;
 @NoArgsConstructor
 @AllArgsConstructor(access = AccessLevel.PRIVATE)
 @Builder(access = AccessLevel.PRIVATE)
-@EntityListeners(value = AuditingEntityListener.class)
+@EntityListeners(value = {AuditingEntityListener.class})
 public class DeliveryPerson extends AuditEntity {
 
     @Id

--- a/com.nuttty.eureka.auth/src/main/java/com/nuttty/eureka/auth/presentation/controller/DeliveryPersonController.java
+++ b/com.nuttty.eureka.auth/src/main/java/com/nuttty/eureka/auth/presentation/controller/DeliveryPersonController.java
@@ -20,21 +20,39 @@ public class DeliveryPersonController {
     // 배송 담당자 등록
     @PostMapping
     public ResultResponse<DeliveryPersonInfoDto> createDeliveryPerson(@RequestHeader("X-User-Role") String role,
-                                                                      @RequestBody DeliveryPersonCreateDto createDto){
+                                                                      @RequestHeader("X-User-Id") Long userId,
+                                                                      @RequestBody DeliveryPersonCreateDto createDto) {
 
         validateUserRole(role);
 
         return ResultResponse.<DeliveryPersonInfoDto>builder()
-                .data(deliveryPersonService.createDeliveryPerson(createDto))
+                .data(deliveryPersonService.createDeliveryPerson(role, userId, createDto))
                 .resultCode(SuccessCode.INSERT_SUCCESS.getStatus())
                 .resultMessage(SuccessCode.INSERT_SUCCESS.getMessage())
                 .build();
     }
 
+    // 배송 담당자 개별 조회
+    @GetMapping("/{delivery_person_id}")
+    public ResultResponse<DeliveryPersonInfoDto> getDeliveryPersonInfo(@RequestHeader("X-User-Role") String role,
+                                                                       @RequestHeader("X-User-Id") Long userId,
+                                                                       @PathVariable("delivery_person_id") Long deliveryPersonId) {
+
+        if (UserRoleEnum.valueOf(role).equals(UserRoleEnum.HUB_COMPANY)) {
+            throw new AccessDeniedException("접근 가능한 권한이 아닙니다.");
+        }
+
+        return ResultResponse.<DeliveryPersonInfoDto>builder()
+                .data(deliveryPersonService.getDeliveryPersonInfo(role, userId, deliveryPersonId))
+                .resultCode(SuccessCode.SELECT_SUCCESS.getStatus())
+                .resultMessage(SuccessCode.SELECT_SUCCESS.getMessage())
+                .build();
+    }
+
 
     // 권한 체크
-    private void validateUserRole(String role){
-        if (!UserRoleEnum.valueOf(role).equals(UserRoleEnum.MASTER) && !UserRoleEnum.valueOf(role).equals(UserRoleEnum.HUB_MANAGER)){
+    private void validateUserRole(String role) {
+        if (!UserRoleEnum.valueOf(role).equals(UserRoleEnum.MASTER) && !UserRoleEnum.valueOf(role).equals(UserRoleEnum.HUB_MANAGER)) {
             throw new AccessDeniedException("접근 가능한 권한이 아닙니다.");
         }
     }

--- a/com.nuttty.eureka.auth/src/main/java/com/nuttty/eureka/auth/presentation/request/DeliveryPersonCreateDto.java
+++ b/com.nuttty.eureka.auth/src/main/java/com/nuttty/eureka/auth/presentation/request/DeliveryPersonCreateDto.java
@@ -10,4 +10,6 @@ public class DeliveryPersonCreateDto {
     private UUID hubId;
     private String deliveryPersonType;
     private String slackId;
+
+    public void setHubId(UUID hubId) {this.hubId = hubId;}
 }


### PR DESCRIPTION
Resolves: #72, Related: #67

## 이슈 번호

Issue📌: #72

## PR 체크리스트
- [x] 커밋 컨벤션에 맞게 작성했는가?
- [x] PR 전에 dev를 pull 받았는가?
- [x] PR 전에 develop 브랜치로 merge 하였는가?


## PR 작업 분류

<!-- Please check the one that applies to this PR using "x". -->

- [x] 신규 기능
- [ ] 버그 수정
- [x] 리팩토링
- [ ] 기타

## 작업 상세 내용

### 1) 배송 담당자의 상세 조회 기능 구현
배송 담당자 등록 여부 검사
권한에 따른 검사
- 배송 담당자 >> 본인 정보만 조회 가능
- 허브 관리자 >> 본인 허브의 배송 담당자 정보만 조회 가능
- 마스터 >> 전부 가능 
### 2) 배송 담당자 등록 기능 권한 검사 추가
- 유저의 권한 별 검사 로직 구분
- 요청된 배송 담당자 등록 타입 별 검사 구분

## 다음 할 일


## 질문 사항


**💬질문 내용**


**🔴 이건 반드시 확인해 주세요!**
