### PR TITLE
[#73] Feat: "배송 담당자 타입 수정 기능 구현 & 배송 담당자 타입별 검사 로직 수정"

### DIFF
--- a/com.nuttty.eureka.auth/src/main/java/com/nuttty/eureka/auth/application/service/DeliveryPersonService.java
+++ b/com.nuttty.eureka.auth/src/main/java/com/nuttty/eureka/auth/application/service/DeliveryPersonService.java
@@ -10,14 +10,18 @@ import com.nuttty.eureka.auth.exception.custom.DeliveryPersonAlreadyExistsExcept
 import com.nuttty.eureka.auth.infrastructure.repository.DeliveryPersonRepository;
 import com.nuttty.eureka.auth.infrastructure.repository.UserRepository;
 import com.nuttty.eureka.auth.presentation.request.DeliveryPersonCreateDto;
+import com.nuttty.eureka.auth.presentation.request.DeliveryPersonTypeUpdateRequestDto;
 import com.nuttty.eureka.auth.presentation.request.HubRequestDto;
 import jakarta.persistence.EntityNotFoundException;
 import lombok.RequiredArgsConstructor;
+import org.springframework.cache.annotation.CacheEvict;
 import org.springframework.cache.annotation.CachePut;
 import org.springframework.cache.annotation.Cacheable;
 import org.springframework.security.access.AccessDeniedException;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
+
+import java.util.UUID;
 
 @Service
 @RequiredArgsConstructor
@@ -41,7 +45,7 @@ public class DeliveryPersonService {
         }
 
         // 허브 관리자 권한 경우
-        if (UserRoleEnum.valueOf(role).equals(UserRoleEnum.HUB_MANAGER)){
+        if (UserRoleEnum.valueOf(role).equals(UserRoleEnum.HUB_MANAGER)) {
             // 허브 존재 여부 검사
             HubRequestDto hubInfo = hubClient.findOneHub(createDto.getHubId()).getBody();
             if (hubInfo == null) {
@@ -49,14 +53,13 @@ public class DeliveryPersonService {
             }
 
             // 배송 담당자를 등록할 허브의 허브관리자와 로그인한 허브 매니저의 일치여부 검사
-            if(!hubInfo.getHubDto().getUser_id().equals(userId)){
+            if (!hubInfo.getHubDto().getUser_id().equals(userId)) {
                 throw new AccessDeniedException("허브 관리자님의 허브가 아닙니다.");
             }
         }
 
         // 배송담당자 타입이 업체 배송 담당자인 경우, 소속 허브ID가 존재하는 허브인지 확인
-        if (DeliveryPersonTypeEnum.valueOf(createDto.getDeliveryPersonType())
-                .equals(DeliveryPersonTypeEnum.COMPANY_DELIVERY_PERSON)) {
+        if (DeliveryPersonTypeEnum.valueOf(createDto.getDeliveryPersonType()).equals(DeliveryPersonTypeEnum.COMPANY_DELIVERY_PERSON)) {
             HubRequestDto hubInfo = hubClient.findOneHub(createDto.getHubId()).getBody();
             if (hubInfo == null) {
                 throw new EntityNotFoundException("등록되지 않은 허브입니다.");
@@ -90,24 +93,85 @@ public class DeliveryPersonService {
         DeliveryPerson deliveryPerson = deliveryPersonRepository.findById(deliveryPersonId)
                 .orElseThrow(() -> new EntityNotFoundException("등록되지 않은 배송 담당자입니다."));
 
-        // 권한에 따른 구분
-        if (UserRoleEnum.valueOf(role).equals(UserRoleEnum.HUB_DELIVERY_PERSON)) { // 권한 == 배송 담당자
+        // 권한 == 배송 담당자
+        if (UserRoleEnum.valueOf(role).equals(UserRoleEnum.HUB_DELIVERY_PERSON)) {
             if (!userId.equals(deliveryPersonId)) { // 본인의 정보만 조회 가능 - deliveryPersonId == userId
                 throw new AccessDeniedException("본인의 정보가 아닙니다.");
             }
+        }
+        // 권한 == 허브 관리자
+        else if (UserRoleEnum.valueOf(role).equals(UserRoleEnum.HUB_MANAGER)) {
+            // 업체 배송 담당자 경우 허브 Id 존재 - 소속 허브Id 관리자와 로그인 유저 일치 여부 검사
+            if (deliveryPerson.getDeliveryPersonType().equals(DeliveryPersonTypeEnum.COMPANY_DELIVERY_PERSON)) {
+                // 배송 담당자의 허브의 허브 관리자 Id 가져오기
+                HubRequestDto hubInfo = hubClient.findOneHub(deliveryPerson.getHubId()).getBody();
+                if (hubInfo == null) {
+                    throw new EntityNotFoundException("등록되지 않은 허브입니다.");
+                }
+                // 로그인한 유저와 허브 관리자 Id 비교
+                if (!userId.equals(hubInfo.getHubDto().getUser_id())) {
+                    throw new AccessDeniedException("허브 관리자님 허브 소속의 배송담당자가 아닙니다.");
+                }
+            }
+        }
 
-        } else if (UserRoleEnum.valueOf(role).equals(UserRoleEnum.HUB_MANAGER)) { // 권한 == 허브 관리자
-            // 배송 담당자의 허브의 허브 관리자 Id 가져오기
-            HubRequestDto hubInfo = hubClient.findOneHub(deliveryPerson.getHubId()).getBody();
+        return DeliveryPersonInfoDto.of(deliveryPerson);
+    }
+
+
+    // 배송 담당자 정보 수정
+    @Transactional
+    @CachePut(cacheNames = "deliveryPersonInfoCache", key = "#role + ':' + #userId + ':' + #deliveryPersonId")
+    @CacheEvict(cacheNames = {"deliveryPersonInfoCache", "deliveryPersonSearchInfoCache"}, allEntries = true)
+    public DeliveryPersonInfoDto updateDeliveryPersonType(String role, Long userId, Long deliveryPersonId, DeliveryPersonTypeUpdateRequestDto updateDto) {
+        // 배송 담당자 등록 여부 검사
+        DeliveryPerson deliveryPerson = deliveryPersonRepository.findById(deliveryPersonId)
+                .orElseThrow(() -> new EntityNotFoundException("등록되지 않은 배송 담당자입니다."));
+
+        // 권한 == 허브 관리자
+        if (UserRoleEnum.valueOf(role).equals(UserRoleEnum.HUB_MANAGER)) {
+            // 업체 배송 담당자 경우 허브 Id 존재 - 소속 허브Id 관리자와 로그인 유저 일치 여부 검사
+            if (deliveryPerson.getDeliveryPersonType().equals(DeliveryPersonTypeEnum.COMPANY_DELIVERY_PERSON)) {
+                // 배송 담당자의 허브의 허브 관리자 Id 가져오기
+                HubRequestDto hubInfo = hubClient.findOneHub(deliveryPerson.getHubId()).getBody();
+                if (hubInfo == null) {
+                    throw new EntityNotFoundException("등록되지 않은 허브입니다.");
+                }
+                // 로그인한 유저와 허브 관리자 Id 비교
+                if (!userId.equals(hubInfo.getHubDto().getUser_id())) {
+                    throw new AccessDeniedException("허브 관리자님 허브 소속의 배송담당자가 아닙니다.");
+                }
+            }
+            // 허브 이동 배송 담당자 경우 소속된 hubId 존재X - 검사 필요 X
+        }
+        // 권한 == 마스터 >> 검사 필요 X
+
+        // 기존 배송 담당자 타입이 배송 담당자인 경우를 확인하는 것은 불필요하다 생각 됨 >> 생성할때 이미 허브의 존재를 확인했기 때문에
+
+        DeliveryPersonTypeEnum updateType = DeliveryPersonTypeEnum.valueOf(updateDto.getType()); // 수정할 타입
+        UUID updateHubId = null; // 수정할 허브 id
+        // 수정할 배송 담당자 타입이 업체 배송 담당자인 경우, 소속 허브ID가 존재하는 허브인지 확인 ;
+        if (updateType.equals(DeliveryPersonTypeEnum.COMPANY_DELIVERY_PERSON)) {
+            HubRequestDto hubInfo = hubClient.findOneHub(updateDto.getHubId()).getBody();
             if (hubInfo == null) {
                 throw new EntityNotFoundException("등록되지 않은 허브입니다.");
             }
 
-            // 로그인한 유저와 허브 관리자 Id 비교
-            if (!userId.equals(hubInfo.getHubDto().getUser_id())) {
-                throw new AccessDeniedException("허브 관리자님 허브 소속의 배송담당자가 아닙니다.");
+            // 권한 == 허브 관리자
+            if (UserRoleEnum.valueOf(role).equals(UserRoleEnum.HUB_MANAGER)) {
+                // 로그인 유저와 업데이트할 허브 Id 일치 여부 검사
+                if (!userId.equals(hubInfo.getHubDto().getUser_id())) {
+                    throw new AccessDeniedException("해당 허브는 허브 관리자님의 허브가 아닙니다.");
+                }
             }
+            // 권한 == 마스터 >> 검사 필요 X
+
+            // 허브가 존재하면 허브 아이디 지정
+            updateHubId = hubInfo.getHubDto().getHub_id();
         }
+
+        // 배송 담당자 타입 업데이트
+        deliveryPerson.updateDeliveryPersonType(updateType, updateHubId);
 
         return DeliveryPersonInfoDto.of(deliveryPerson);
     }

--- a/com.nuttty.eureka.auth/src/main/java/com/nuttty/eureka/auth/application/service/UserService.java
+++ b/com.nuttty.eureka.auth/src/main/java/com/nuttty/eureka/auth/application/service/UserService.java
@@ -38,7 +38,7 @@ public class UserService {
     // 회원 권한 수정 - 토큰 재발급
     @Transactional
     @CachePut(cacheNames = "userInfoCache", key = "#userId")
-    @CacheEvict(cacheNames = "{userInfoCache, userSearchInfoCache}", allEntries = true)
+    @CacheEvict(cacheNames = {"userInfoCache", "userSearchInfoCache"}, allEntries = true)
     public UserInfoDto updateUserRole(Long userId, UserRoleUpdateRequestDto updateRequestDto) {
         // 조회 유저 가입 여부 검사
         User user = userRepository.findById(userId)
@@ -52,7 +52,7 @@ public class UserService {
 
     // 회원 탈퇴
     @Transactional
-    @CacheEvict(cacheNames = "{userInfoCache, userSearchInfoCache}", allEntries = true)
+    @CacheEvict(cacheNames = {"userInfoCache", "userSearchInfoCache"}, allEntries = true)
     public String deleteUserInfo(Long userId) {
         // 조회 유저 가입 여부 검사
         User user = userRepository.findById(userId)

--- a/com.nuttty.eureka.auth/src/main/java/com/nuttty/eureka/auth/domain/model/DeliveryPerson.java
+++ b/com.nuttty.eureka.auth/src/main/java/com/nuttty/eureka/auth/domain/model/DeliveryPerson.java
@@ -44,4 +44,11 @@ public class DeliveryPerson extends AuditEntity {
                 .slackId(slackId)
                 .build();
     }
+
+
+    // 배송 담당자 정보 수정
+    public void updateDeliveryPersonType(DeliveryPersonTypeEnum deliveryPersonType, UUID hubId){
+        this.deliveryPersonType = deliveryPersonType;
+        this.hubId = hubId;
+    }
 }

--- a/com.nuttty.eureka.auth/src/main/java/com/nuttty/eureka/auth/presentation/controller/DeliveryPersonController.java
+++ b/com.nuttty.eureka.auth/src/main/java/com/nuttty/eureka/auth/presentation/controller/DeliveryPersonController.java
@@ -4,6 +4,7 @@ import com.nuttty.eureka.auth.application.dto.DeliveryPersonInfoDto;
 import com.nuttty.eureka.auth.application.service.DeliveryPersonService;
 import com.nuttty.eureka.auth.domain.model.UserRoleEnum;
 import com.nuttty.eureka.auth.presentation.request.DeliveryPersonCreateDto;
+import com.nuttty.eureka.auth.presentation.request.DeliveryPersonTypeUpdateRequestDto;
 import com.nuttty.eureka.auth.util.ResultResponse;
 import com.nuttty.eureka.auth.util.SuccessCode;
 import lombok.RequiredArgsConstructor;
@@ -46,6 +47,21 @@ public class DeliveryPersonController {
                 .data(deliveryPersonService.getDeliveryPersonInfo(role, userId, deliveryPersonId))
                 .resultCode(SuccessCode.SELECT_SUCCESS.getStatus())
                 .resultMessage(SuccessCode.SELECT_SUCCESS.getMessage())
+                .build();
+    }
+
+    // 배송 담당자 정보 수정
+    @PatchMapping("/{delivery_person_id}")
+    public ResultResponse<DeliveryPersonInfoDto> updateDeliveryPersonType(@RequestHeader("X-User-Role") String role,
+                                                                          @RequestHeader("X-User-Id") Long userId,
+                                                                          @PathVariable("delivery_person_id") Long deliveryPersonId,
+                                                                          @RequestBody DeliveryPersonTypeUpdateRequestDto updateDto){
+        validateUserRole(role);
+
+        return ResultResponse.<DeliveryPersonInfoDto>builder()
+                .data(deliveryPersonService.updateDeliveryPersonType(role, userId, deliveryPersonId, updateDto))
+                .resultCode(SuccessCode.UPDATE_SUCCESS.getStatus())
+                .resultMessage(SuccessCode.UPDATE_SUCCESS.getMessage())
                 .build();
     }
 

--- a/com.nuttty.eureka.auth/src/main/java/com/nuttty/eureka/auth/presentation/request/DeliveryPersonTypeUpdateRequestDto.java
+++ b/com.nuttty.eureka.auth/src/main/java/com/nuttty/eureka/auth/presentation/request/DeliveryPersonTypeUpdateRequestDto.java
@@ -1,0 +1,11 @@
+package com.nuttty.eureka.auth.presentation.request;
+
+import lombok.Getter;
+
+import java.util.UUID;
+
+@Getter
+public class DeliveryPersonTypeUpdateRequestDto {
+    private String type;
+    private UUID hubId;
+}


### PR DESCRIPTION
Resolves: #73, Related: #59

## 이슈 번호

Issue📌: #73

## PR 체크리스트
- [x] 커밋 컨벤션에 맞게 작성했는가?
- [x] PR 전에 dev를 pull 받았는가?
- [x] PR 전에 develop 브랜치로 merge 하였는가?


## PR 작업 분류

<!-- Please check the one that applies to this PR using "x". -->

- [x] 신규 기능
- [ ] 버그 수정
- [x] 리팩토링
- [ ] 기타

## 작업 상세 내용
### 1) 배송 담당자의 타입을 수정하는 기능
- 배송 담당자 등록 여부 검사
- 유저 권한 체크
- - 허브 관리자
- - - 업체 배송 담당자 타입 >> 소속 허브 Id 관리자와 로그인 유저 일치 여부 검사
- - - 허브 이동 배송 담당자 타입 >> 검사 필요 x
- - 마스터 관리자
- - - 검사 필요 x
- 수정할 배송 담당자 타입 체크
- - 업체 배송 담당자
- - - 소속 허브 존재 여부 체크
- - - 허브 관리자 권한
- - - - 로그인 유저 & 업데이트 할 허브 Id 일치 여부 체크
- - - 마스터 관리자
- - - - 검사 필요 x
- - - 허브 존재 시 아이디 지정
- 배송 담당자 정보 업데이트

### 2) 회원 정보 캐싱 기능 수정
CacheEvict 배열 오타 수정

## 다음 할 일


## 질문 사항


**💬질문 내용**


**🔴 이건 반드시 확인해 주세요!**
