### PR TITLE
[#74] Feat: "배송 담당자 정보 삭제 기능 구현"

### DIFF
--- a/com.nuttty.eureka.auth/src/main/java/com/nuttty/eureka/auth/presentation/controller/DeliveryPersonController.java
+++ b/com.nuttty.eureka.auth/src/main/java/com/nuttty/eureka/auth/presentation/controller/DeliveryPersonController.java
@@ -55,13 +55,28 @@ public class DeliveryPersonController {
     public ResultResponse<DeliveryPersonInfoDto> updateDeliveryPersonType(@RequestHeader("X-User-Role") String role,
                                                                           @RequestHeader("X-User-Id") Long userId,
                                                                           @PathVariable("delivery_person_id") Long deliveryPersonId,
-                                                                          @RequestBody DeliveryPersonTypeUpdateRequestDto updateDto){
+                                                                          @RequestBody DeliveryPersonTypeUpdateRequestDto updateDto) {
         validateUserRole(role);
 
         return ResultResponse.<DeliveryPersonInfoDto>builder()
                 .data(deliveryPersonService.updateDeliveryPersonType(role, userId, deliveryPersonId, updateDto))
                 .resultCode(SuccessCode.UPDATE_SUCCESS.getStatus())
                 .resultMessage(SuccessCode.UPDATE_SUCCESS.getMessage())
+                .build();
+    }
+
+    // 배송 담당자 삭제
+    @DeleteMapping("/{delivery_person_id}")
+    public ResultResponse<String> deleteDeliveryPerson(@RequestHeader("X-User-Role") String role,
+                                                       @RequestHeader("X-User-Id") Long userId,
+                                                       @RequestHeader("X-User-Email") String email,
+                                                       @PathVariable("delivery_person_id") Long deliveryPersonId) {
+        validateUserRole(role);
+
+        return ResultResponse.<String>builder()
+                .data(deliveryPersonService.deleteDeliveryPerson(role, userId, email, deliveryPersonId))
+                .resultCode(SuccessCode.DELETE_SUCCESS.getStatus())
+                .resultMessage(SuccessCode.DELETE_SUCCESS.getMessage())
                 .build();
     }
 


### PR DESCRIPTION
Resolves: #74

## 이슈 번호

Issue📌: #74 

## PR 체크리스트
- [x] 커밋 컨벤션에 맞게 작성했는가?
- [x] PR 전에 dev를 pull 받았는가?
- [x] PR 전에 develop 브랜치로 merge 하였는가?


## PR 작업 분류

<!-- Please check the one that applies to this PR using "x". -->

- [x] 신규 기능
- [ ] 버그 수정
- [ ] 리팩토링
- [ ] 기타

## 작업 상세 내용
### 배송 담당자의 정보를 논리적 삭제하는 기능
- 배송 담당자 등록 여부 검사
- 유저 권한 체크
- - 허브 관리자
- - - 업체 배송 담당자 타입 >> 소속 허브 Id 관리자와 로그인 유저 일치 여부 검사
- - - 허브 이동 배송 담당자 타입 >> 검사 필요 x
- - 마스터 관리자
- - - 검사 필요 x
## 다음 할 일


## 질문 사항


**💬질문 내용**


**🔴 이건 반드시 확인해 주세요!**
