### PR TITLE
[#99] MSA swagger ui적용 api 자동화

### DIFF
--- a/com.nuttty.eureka.ai/build.gradle
+++ b/com.nuttty.eureka.ai/build.gradle
@@ -59,6 +59,9 @@ dependencies {
 	annotationProcessor 'org.projectlombok:lombok'
 	testImplementation 'org.springframework.boot:spring-boot-starter-test'
 	testRuntimeOnly 'org.junit.platform:junit-platform-launcher'
+
+	// Springdoc OpenAPI
+	implementation group: 'org.springdoc', name: 'springdoc-openapi-starter-webmvc-ui', version: '2.2.0'
 }
 
 dependencyManagement {

--- a/com.nuttty.eureka.ai/src/main/java/com/nuttty/eureka/ai/config/SwaggerConfig.java
+++ b/com.nuttty.eureka.ai/src/main/java/com/nuttty/eureka/ai/config/SwaggerConfig.java
@@ -1,0 +1,31 @@
+package com.nuttty.eureka.ai.config;
+
+import io.swagger.v3.oas.annotations.OpenAPIDefinition;
+import io.swagger.v3.oas.annotations.info.Info;
+import io.swagger.v3.oas.models.Components;
+import io.swagger.v3.oas.models.OpenAPI;
+import io.swagger.v3.oas.models.security.SecurityRequirement;
+import io.swagger.v3.oas.models.security.SecurityScheme;
+import io.swagger.v3.oas.models.servers.Server;
+import lombok.RequiredArgsConstructor;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+@Configuration
+@RequiredArgsConstructor
+@OpenAPIDefinition(
+        info = @Info(title = "AI Service", version = "1.0.0", description = "Team nuTTTy의 AI Serivce입니다.")
+)
+public class SwaggerConfig {
+    @Bean
+    public OpenAPI openAPI() {
+        return new OpenAPI()
+                .components(new Components()
+                        .addSecuritySchemes("bearer-jwt", new SecurityScheme()
+                                .type(SecurityScheme.Type.HTTP)
+                                .scheme("bearer")
+                                .bearerFormat("JWT")))
+                .addSecurityItem(new SecurityRequirement().addList("bearer-jwt"))
+                .addServersItem(new Server().url("/"));
+    }
+}

--- a/com.nuttty.eureka.ai/src/main/java/com/nuttty/eureka/ai/config/WebConfig.java
+++ b/com.nuttty.eureka.ai/src/main/java/com/nuttty/eureka/ai/config/WebConfig.java
@@ -1,0 +1,17 @@
+package com.nuttty.eureka.ai.config;
+
+import org.springframework.context.annotation.Configuration;
+import org.springframework.web.servlet.config.annotation.CorsRegistry;
+import org.springframework.web.servlet.config.annotation.WebMvcConfigurer;
+
+@Configuration
+public class WebConfig implements WebMvcConfigurer {
+    @Override
+    public void addCorsMappings(CorsRegistry registry) {
+        registry.addMapping("/**") // 모든 경로에 대해 CORS 설정
+                .allowedOriginPatterns("http://localhost:*") // 모든 출처 허용
+                .allowedMethods("GET", "POST", "PUT", "DELETE", "OPTIONS")
+                .allowedHeaders("Authorization", "Content-Type", "X-User-Id", "X-User-Role", "X-User-Email")
+                .allowCredentials(true);
+    }
+}

--- a/com.nuttty.eureka.ai/src/main/resources/application.yml
+++ b/com.nuttty.eureka.ai/src/main/resources/application.yml
@@ -42,3 +42,14 @@ eureka:
 
 slack:
   botKey: ${SLACK_API_TOKEN}
+
+# springdoc-openapi-ui
+springdoc:
+  api-docs:
+    version: openapi_3_1
+    enabled: true
+    path: /v3/api-docs
+    # 게이트웨이 라우팅에서 prefix를 제거하지 않았다면 해당 설정을 추가
+  enable-spring-security: true
+  default-consumes-media-type: application/json
+  default-produces-media-type: application/json

--- a/com.nuttty.eureka.auth/build.gradle
+++ b/com.nuttty.eureka.auth/build.gradle
@@ -64,6 +64,9 @@ dependencies {
 	testImplementation 'org.springframework.boot:spring-boot-starter-test'
 	testImplementation 'org.springframework.security:spring-security-test'
 	testRuntimeOnly 'org.junit.platform:junit-platform-launcher'
+
+	// Springdoc OpenAPI
+	implementation group: 'org.springdoc', name: 'springdoc-openapi-starter-webmvc-ui', version: '2.2.0'
 }
 
 dependencyManagement {

--- a/com.nuttty.eureka.auth/src/main/java/com/nuttty/eureka/auth/config/SwaggerConfig.java
+++ b/com.nuttty.eureka.auth/src/main/java/com/nuttty/eureka/auth/config/SwaggerConfig.java
@@ -1,0 +1,31 @@
+package com.nuttty.eureka.auth.config;
+
+import io.swagger.v3.oas.annotations.OpenAPIDefinition;
+import io.swagger.v3.oas.annotations.info.Info;
+import io.swagger.v3.oas.models.Components;
+import io.swagger.v3.oas.models.OpenAPI;
+import io.swagger.v3.oas.models.security.SecurityRequirement;
+import io.swagger.v3.oas.models.security.SecurityScheme;
+import io.swagger.v3.oas.models.servers.Server;
+import lombok.RequiredArgsConstructor;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+@Configuration
+@RequiredArgsConstructor
+@OpenAPIDefinition(
+        info = @Info(title = "Auth Service", version = "1.0.0", description = "Team nuTTTy의 Auth Serivce입니다.")
+)
+public class SwaggerConfig {
+    @Bean
+    public OpenAPI openAPI() {
+        return new OpenAPI()
+                .components(new Components()
+                        .addSecuritySchemes("bearer-jwt", new SecurityScheme()
+                                .type(SecurityScheme.Type.HTTP)
+                                .scheme("bearer")
+                                .bearerFormat("JWT")))
+                .addSecurityItem(new SecurityRequirement().addList("bearer-jwt"))
+                .addServersItem(new Server().url("/"));
+    }
+}

--- a/com.nuttty.eureka.auth/src/main/java/com/nuttty/eureka/auth/config/WebConfig.java
+++ b/com.nuttty.eureka.auth/src/main/java/com/nuttty/eureka/auth/config/WebConfig.java
@@ -1,0 +1,17 @@
+package com.nuttty.eureka.auth.config;
+
+import org.springframework.context.annotation.Configuration;
+import org.springframework.web.servlet.config.annotation.CorsRegistry;
+import org.springframework.web.servlet.config.annotation.WebMvcConfigurer;
+
+@Configuration
+public class WebConfig implements WebMvcConfigurer {
+    @Override
+    public void addCorsMappings(CorsRegistry registry) {
+        registry.addMapping("/**") // 모든 경로에 대해 CORS 설정
+                .allowedOriginPatterns("http://localhost:*") // 모든 출처 허용
+                .allowedMethods("GET", "POST", "PUT", "DELETE", "OPTIONS")
+                .allowedHeaders("Authorization", "Content-Type", "X-User-Id", "X-User-Role", "X-User-Email")
+                .allowCredentials(true);
+    }
+}

--- a/com.nuttty.eureka.auth/src/main/resources/application.yml
+++ b/com.nuttty.eureka.auth/src/main/resources/application.yml
@@ -39,3 +39,14 @@ jwt:
   access-expiration: 3600000
   secret-key: "7Iqk7YyM66W07YOA7L2U65Sp7YG065-9U3ByaW5n6rCV7J2Y7Yqc7YSw7LWc7JuQ67mI7J6F64uI64ukLg=="
   admin-token: AIzaSyBZFANrsha1UH5CaSDUxtfdXaTQ5yOtPhE
+
+# springdoc-openapi-ui
+springdoc:
+  api-docs:
+    version: openapi_3_1
+    enabled: true
+    path: /v3/api-docs
+    # 게이트웨이 라우팅에서 prefix를 제거하지 않았다면 해당 설정을 추가
+  enable-spring-security: true
+  default-consumes-media-type: application/json
+  default-produces-media-type: application/json

--- a/com.nuttty.eureka.company/build.gradle
+++ b/com.nuttty.eureka.company/build.gradle
@@ -57,6 +57,10 @@ dependencies {
 	annotationProcessor 'org.projectlombok:lombok'
 	testImplementation 'org.springframework.boot:spring-boot-starter-test'
 	testRuntimeOnly 'org.junit.platform:junit-platform-launcher'
+
+	// Springdoc OpenAPI
+	implementation group: 'org.springdoc', name: 'springdoc-openapi-starter-webmvc-ui', version: '2.2.0'
+
 }
 
 dependencyManagement {

--- a/com.nuttty.eureka.company/src/main/java/com/nuttty/eureka/company/config/SwaggerConfig.java
+++ b/com.nuttty.eureka.company/src/main/java/com/nuttty/eureka/company/config/SwaggerConfig.java
@@ -1,0 +1,31 @@
+package com.nuttty.eureka.company.config;
+
+import io.swagger.v3.oas.annotations.OpenAPIDefinition;
+import io.swagger.v3.oas.annotations.info.Info;
+import io.swagger.v3.oas.models.Components;
+import io.swagger.v3.oas.models.OpenAPI;
+import io.swagger.v3.oas.models.security.SecurityRequirement;
+import io.swagger.v3.oas.models.security.SecurityScheme;
+import io.swagger.v3.oas.models.servers.Server;
+import lombok.RequiredArgsConstructor;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+@Configuration
+@RequiredArgsConstructor
+@OpenAPIDefinition(
+        info = @Info(title = "Company Service", version = "1.0.0", description = "Team nuTTTy의 Company Serivce입니다.")
+)
+public class SwaggerConfig {
+    @Bean
+    public OpenAPI openAPI() {
+        return new OpenAPI()
+                .components(new Components()
+                        .addSecuritySchemes("bearer-jwt", new SecurityScheme()
+                                .type(SecurityScheme.Type.HTTP)
+                                .scheme("bearer")
+                                .bearerFormat("JWT")))
+                .addSecurityItem(new SecurityRequirement().addList("bearer-jwt"))
+                .addServersItem(new Server().url("/"));
+    }
+}

--- a/com.nuttty.eureka.company/src/main/java/com/nuttty/eureka/company/config/WebConfig.java
+++ b/com.nuttty.eureka.company/src/main/java/com/nuttty/eureka/company/config/WebConfig.java
@@ -1,0 +1,17 @@
+package com.nuttty.eureka.company.config;
+
+import org.springframework.context.annotation.Configuration;
+import org.springframework.web.servlet.config.annotation.CorsRegistry;
+import org.springframework.web.servlet.config.annotation.WebMvcConfigurer;
+
+@Configuration
+public class WebConfig implements WebMvcConfigurer {
+    @Override
+    public void addCorsMappings(CorsRegistry registry) {
+        registry.addMapping("/**") // 모든 경로에 대해 CORS 설정
+                .allowedOriginPatterns("http://localhost:*") // 모든 출처 허용
+                .allowedMethods("GET", "POST", "PUT", "DELETE", "OPTIONS")
+                .allowedHeaders("Authorization", "Content-Type", "X-User-Id", "X-User-Role", "X-User-Email")
+                .allowCredentials(true);
+    }
+}

--- a/com.nuttty.eureka.company/src/main/resources/application.yml
+++ b/com.nuttty.eureka.company/src/main/resources/application.yml
@@ -37,3 +37,14 @@ eureka:
   client:
     service-url:
       defaultZone: http://localhost:19090/eureka/
+
+# springdoc-openapi-ui
+springdoc:
+  api-docs:
+    version: openapi_3_1
+    enabled: true
+    path: /v3/api-docs
+    # 게이트웨이 라우팅에서 prefix를 제거하지 않았다면 해당 설정을 추가
+  enable-spring-security: true
+  default-consumes-media-type: application/json
+  default-produces-media-type: application/json

--- a/com.nuttty.eureka.gateway/build.gradle
+++ b/com.nuttty.eureka.gateway/build.gradle
@@ -41,6 +41,9 @@ dependencies {
 	testImplementation 'org.springframework.boot:spring-boot-starter-test'
 	testImplementation 'io.projectreactor:reactor-test'
 	testRuntimeOnly 'org.junit.platform:junit-platform-launcher'
+
+	// Springdoc OpenAPI
+	implementation group: 'org.springdoc', name: 'springdoc-openapi-starter-webflux-ui', version: '2.2.0'
 }
 
 dependencyManagement {

--- a/com.nuttty.eureka.gateway/src/main/resources/application.yml
+++ b/com.nuttty.eureka.gateway/src/main/resources/application.yml
@@ -42,3 +42,23 @@ jwt:
   access-expiration: 3600000
   secret-key: "7Iqk7YyM66W07YOA7L2U65Sp7YG065-9U3ByaW5n6rCV7J2Y7Yqc7YSw7LWc7JuQ67mI7J6F64uI64ukLg=="
   admin-token: AIzaSyBZFANrsha1UH5CaSDUxtfdXaTQ5yOtPhE
+
+springdoc:
+  swagger-ui:
+    use-root-path: true
+    urls[0]:
+      name: Auth Service
+      url: http://localhost:19093/v3/api-docs
+    urls[1]:
+      name: Order Service
+      url: http://localhost:19094/v3/api-docs
+    urls[2]:
+      name: Company Service
+      url: http://localhost:19095/v3/api-docs
+    urls[3]:
+      name: Hub Service
+      url: http://localhost:19096/v3/api-docs
+    urls[4]:
+      name: AI Service
+      url: http://localhost:19097/v3/api-docs
+

--- a/com.nuttty.eureka.hub/build.gradle
+++ b/com.nuttty.eureka.hub/build.gradle
@@ -59,6 +59,9 @@ dependencies {
 	annotationProcessor 'org.projectlombok:lombok'
 	testImplementation 'org.springframework.boot:spring-boot-starter-test'
 	testRuntimeOnly 'org.junit.platform:junit-platform-launcher'
+
+	// Springdoc OpenAPI
+	implementation group: 'org.springdoc', name: 'springdoc-openapi-starter-webmvc-ui', version: '2.2.0'
 }
 
 dependencyManagement {

--- a/com.nuttty.eureka.hub/src/main/java/com/nuttty/eureka/hub/config/SwaggerConfig.java
+++ b/com.nuttty.eureka.hub/src/main/java/com/nuttty/eureka/hub/config/SwaggerConfig.java
@@ -5,6 +5,7 @@ import io.swagger.v3.oas.models.OpenAPI;
 import io.swagger.v3.oas.models.info.Info;
 import io.swagger.v3.oas.models.security.SecurityRequirement;
 import io.swagger.v3.oas.models.security.SecurityScheme;
+import io.swagger.v3.oas.models.servers.Server;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 
@@ -13,21 +14,13 @@ public class SwaggerConfig {
     @Bean
     public OpenAPI customOpenAPI() {
         return new OpenAPI()
-                .info(new Info().title("3NT_Delivery_Shop").description("3NT_Delivery_Shop API Swaggger UI 입니다.").version("1.0.0"))
+                .info(new Info().title("Hub Service").description("Team nuTTTy의 Hub Serivce입니다.").version("1.0.0"))
                 .components(new Components()
                         .addSecuritySchemes("bearer-jwt", new SecurityScheme()
                                 .type(SecurityScheme.Type.HTTP)
                                 .scheme("bearer")
                                 .bearerFormat("JWT")))
-                .addSecurityItem(new SecurityRequirement().addList("bearer-jwt"));
+                .addSecurityItem(new SecurityRequirement().addList("bearer-jwt"))
+                .addServersItem(new Server().url("/"));
     }
-
-//    @Bean
-//    public GroupedOpenApi customApi() {
-//        return GroupedOpenApi.builder()
-//                .group("api")
-//                .pathsToMatch("/api/**")
-//                .build();
-//    }
-
 }

--- a/com.nuttty.eureka.hub/src/main/java/com/nuttty/eureka/hub/config/WebConfig.java
+++ b/com.nuttty.eureka.hub/src/main/java/com/nuttty/eureka/hub/config/WebConfig.java
@@ -1,0 +1,17 @@
+package com.nuttty.eureka.hub.config;
+
+import org.springframework.context.annotation.Configuration;
+import org.springframework.web.servlet.config.annotation.CorsRegistry;
+import org.springframework.web.servlet.config.annotation.WebMvcConfigurer;
+
+@Configuration
+public class WebConfig implements WebMvcConfigurer {
+    @Override
+    public void addCorsMappings(CorsRegistry registry) {
+        registry.addMapping("/**") // 모든 경로에 대해 CORS 설정
+                .allowedOriginPatterns("http://localhost:*") // 모든 출처 허용
+                .allowedMethods("GET", "POST", "PUT", "DELETE", "OPTIONS")
+                .allowedHeaders("Authorization", "Content-Type", "X-User-Id", "X-User-Role", "X-User-Email")
+                .allowCredentials(true);
+    }
+}

--- a/com.nuttty.eureka.hub/src/main/resources/application.yml
+++ b/com.nuttty.eureka.hub/src/main/resources/application.yml
@@ -37,3 +37,14 @@ eureka:
   client:
     service-url:
       defaultZone: http://localhost:19090/eureka/
+
+# springdoc-openapi-ui
+springdoc:
+  api-docs:
+    version: openapi_3_1
+    enabled: true
+    path: /v3/api-docs
+    # 게이트웨이 라우팅에서 prefix를 제거하지 않았다면 해당 설정을 추가
+  enable-spring-security: true
+  default-consumes-media-type: application/json
+  default-produces-media-type: application/json

--- a/com.nuttty.eureka.order/build.gradle
+++ b/com.nuttty.eureka.order/build.gradle
@@ -59,6 +59,10 @@ dependencies {
 
 	// Fegin Client(Patch method support)
 	implementation 'io.github.openfeign:feign-hc5'
+
+	// Springdoc OpenAPI
+	implementation group: 'org.springdoc', name: 'springdoc-openapi-starter-webmvc-ui', version: '2.2.0'
+
 }
 
 dependencyManagement {

--- a/com.nuttty.eureka.order/src/main/java/com/nuttty/eureka/order/config/SwaggerConfig.java
+++ b/com.nuttty.eureka.order/src/main/java/com/nuttty/eureka/order/config/SwaggerConfig.java
@@ -1,0 +1,31 @@
+package com.nuttty.eureka.order.config;
+
+import io.swagger.v3.oas.annotations.OpenAPIDefinition;
+import io.swagger.v3.oas.annotations.info.Info;
+import io.swagger.v3.oas.models.Components;
+import io.swagger.v3.oas.models.OpenAPI;
+import io.swagger.v3.oas.models.security.SecurityRequirement;
+import io.swagger.v3.oas.models.security.SecurityScheme;
+import io.swagger.v3.oas.models.servers.Server;
+import lombok.RequiredArgsConstructor;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+@Configuration
+@RequiredArgsConstructor
+@OpenAPIDefinition(
+        info = @Info(title = "Order Service", version = "1.0.0", description = "Team nuTTTy의 Order Serivce입니다.")
+)
+public class SwaggerConfig {
+    @Bean
+    public OpenAPI openAPI() {
+        return new OpenAPI()
+                .components(new Components()
+                        .addSecuritySchemes("bearer-jwt", new SecurityScheme()
+                                .type(SecurityScheme.Type.HTTP)
+                                .scheme("bearer")
+                                .bearerFormat("JWT")))
+                .addSecurityItem(new SecurityRequirement().addList("bearer-jwt"))
+                .addServersItem(new Server().url("/"));
+    }
+}

--- a/com.nuttty.eureka.order/src/main/java/com/nuttty/eureka/order/config/WebConfig.java
+++ b/com.nuttty.eureka.order/src/main/java/com/nuttty/eureka/order/config/WebConfig.java
@@ -1,0 +1,17 @@
+package com.nuttty.eureka.order.config;
+
+import org.springframework.context.annotation.Configuration;
+import org.springframework.web.servlet.config.annotation.CorsRegistry;
+import org.springframework.web.servlet.config.annotation.WebMvcConfigurer;
+
+@Configuration
+public class WebConfig implements WebMvcConfigurer {
+    @Override
+    public void addCorsMappings(CorsRegistry registry) {
+        registry.addMapping("/**") // 모든 경로에 대해 CORS 설정
+                .allowedOriginPatterns("http://localhost:*") // 모든 출처 허용
+                .allowedMethods("GET", "POST", "PUT", "DELETE", "OPTIONS")
+                .allowedHeaders("Authorization", "Content-Type", "X-User-Id", "X-User-Role", "X-User-Email")
+                .allowCredentials(true);
+    }
+}

--- a/com.nuttty.eureka.order/src/main/resources/application.yml
+++ b/com.nuttty.eureka.order/src/main/resources/application.yml
@@ -34,3 +34,14 @@ eureka:
       defaultZone: http://localhost:19090/eureka/
   instance:
     hostname: localhost
+
+# springdoc-openapi-ui
+springdoc:
+  api-docs:
+    version: openapi_3_1
+    enabled: true
+    path: /v3/api-docs
+    # 게이트웨이 라우팅에서 prefix를 제거하지 않았다면 해당 설정을 추가
+  enable-spring-security: true
+  default-consumes-media-type: application/json
+  default-produces-media-type: application/json


### PR DESCRIPTION
## 이슈 번호

Issue📌: #99 

## PR 체크리스트
- [x] 커밋 컨벤션에 맞게 작성했는가?
- [x] PR 전에 dev를 pull 받았는가?
- [x] PR 전에 develop 브랜치로 merge 하였는가?


## PR 작업 분류

<!-- Please check the one that applies to this PR using "x". -->

- [x] 신규 기능
- [ ] 버그 수정
- [ ] 리팩토링
- [ ] 기타

## 작업 상세 내용
- #99 
  - 각 도메인 별로 swagger관련 작업 세팅 및 실행 테스트를 확인했습니다.
  - 게이트웨이 주소인 localhost:19092로 접속 가능합니다.(AI 서비스는 SLACK_API_TOKEN이 없는 관계로 실행되지않아 테스트는 하지 못하였습니다.)
  - 각 API별 컨트롤러에서 문서화 작업은 별도로 필요하겠습니다.
  
  
![image](https://github.com/user-attachments/assets/650081f0-fc96-4e67-a741-18cb2c5a4819)

![image](https://github.com/user-attachments/assets/a29b56ba-db71-4811-affb-2a2f83fab5f0)
- 토큰을 입력할 때 Bearer[빈칸]을 제외한 토큰 값만 넣으시면 됩니다.

  

## 다음 할 일
- 허브간 이동 정보(소요시간, 이동 거리) 외부 API 연동
- 배송경로 생성 알고리즘 최적화
- Prometheus와 Grafana를 이용해 모니터링 구축

## 질문 사항


**💬질문 내용**


**🔴 이건 반드시 확인해 주세요!**
